### PR TITLE
clear interval when user manually closes oauth window

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function poll(popup, fn) {
   var intervalId = setInterval(function polling() {
     if (popup.closed) {
       clearInterval(intervalId);
-      return
+      return;
     }
     try {
       var documentOrigin = document.location.host;

--- a/index.js
+++ b/index.js
@@ -61,8 +61,9 @@ function poll(popup, fn) {
         popup.close();
         done(null, qs);
       }
+    } else if (popup.closed) {
+      clearInterval(intervalId);
     }
-
   }, 35);
 }
 

--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ function poll(popup, fn) {
   var done = once(fn);
 
   var intervalId = setInterval(function polling() {
+    if (popup.closed) {
+      clearInterval(intervalId);
+      return
+    }
     try {
       var documentOrigin = document.location.host;
       var popupWindowOrigin = popup.location.host;
@@ -61,8 +65,6 @@ function poll(popup, fn) {
         popup.close();
         done(null, qs);
       }
-    } else if (popup.closed) {
-      clearInterval(intervalId);
     }
   }, 35);
 }


### PR DESCRIPTION
When user closes the popup window before oauth process finishing, the time interval is still running in the background.

I add an "else if" statement to check popup window state only after the normal path, this new logic branch will not be touched if oauth finishes properly (success or failure). 